### PR TITLE
handle systems wo yaz-config; use z3950.indexdata.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ The bundled shared object is stored in directory
 
 ## Unix
 
-On Unix, the `yaz-config` utility is used to get compiler flags and
+On Unix, the `pkg-config` utility is used to get compiler flags and
 linker libraries for the shared object. Usually it's enough
 to install as whole. If there are packages for YAZ already, use
-install the "devel" package or "dev" package. Check that `yaz-config`
-is in the `PATH`.
+install the "devel" package or "dev" package.
 
 ## Windows
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The bundled shared object is stored in directory
 
 ## Unix
 
-On Unix, the `pkg-config` utility is used to get compiler flags and
+On Unix, the `yaz-config` utility is used to get compiler flags and
 linker libraries for the shared object. Usually it's enough
 to install as whole. If there are packages for YAZ already, use
 install the "devel" package or "dev" package.

--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         </os>
       </activation>
       <properties>
-        <pkg.config>pkg-config</pkg.config>
+        <yaz.config>${basedir}/yaz-config-wrap.sh</yaz.config>
         <swig>swig</swig>
         <native.file>libyaz4j.so</native.file>
         <compiler>g++</compiler>
@@ -250,12 +250,10 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" executable="${pkg.config}" outputproperty="yaz.cflags">
-                      <arg value="yaz" />
+                    <exec failonerror="true" executable="${yaz.config}" outputproperty="yaz.cflags">
                       <arg value="--cflags" />
                     </exec>
-                    <exec failonerror="true" executable="${pkg.config}" outputproperty="yaz.libs">
-                      <arg value="yaz" />
+                    <exec failonerror="true" executable="${yaz.config}" outputproperty="yaz.libs">
                       <arg value="--libs" />
                     </exec>
                     <mkdir dir="${basedir}/target" />

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
                       <arg value="-I${jdk.include}" />
                       <arg value="-I${jdk.include}/win32" />
                       <arg value="-I${basedir}/src/main/native" />
-                      <arg value="${yaz.clags}" />
+                      <arg value="${yaz.cflags}" />
                       <arg value="/Fo${basedir}/target/libyaz4j.obj" />
                       <arg value="-c" />
                       <arg value="${basedir}/target/generated-sources/native/libyaz4j.cpp" />

--- a/pom.xml
+++ b/pom.xml
@@ -112,14 +112,13 @@
             <inherited>false</inherited>
             <configuration>
               <target>
-                <echo message="Using CFLAGS: ${yaz.cflags} ${yaz.include}" />
+                <echo message="Using CFLAGS: ${yaz.cflags}" />
                 <mkdir dir="target/generated-sources/java/org/yaz4j/jni" />
                 <mkdir dir="target/generated-sources/native" />
                 <mkdir dir="${native.dir}" />
                 <exec failonerror="true" executable="${swig}">
                   <arg value="-Isrc/main/native" />
                   <arg value="${yaz.cflags}" />
-                  <arg value="-I${yaz.include}" />
                   <arg value="-I/usr/include" />
                   <arg value="-outdir" />
                   <arg value="${basedir}/target/generated-sources/java/org/yaz4j/jni" />
@@ -232,8 +231,7 @@
         </os>
       </activation>
       <properties>
-        <!-- yaz-config executable -->
-        <yaz.config>yaz-config</yaz.config>
+        <pkg.config>pkg-config</pkg.config>
         <swig>swig</swig>
         <native.file>libyaz4j.so</native.file>
         <compiler>g++</compiler>
@@ -252,10 +250,12 @@
                 </goals>
                 <configuration>
                   <target>
-                    <exec failonerror="true" executable="${yaz.config}" outputproperty="yaz.cflags">
+                    <exec failonerror="true" executable="${pkg.config}" outputproperty="yaz.cflags">
+                      <arg value="yaz" />
                       <arg value="--cflags" />
                     </exec>
-                    <exec failonerror="true" executable="${yaz.config}" outputproperty="yaz.libs">
+                    <exec failonerror="true" executable="${pkg.config}" outputproperty="yaz.libs">
+                      <arg value="yaz" />
                       <arg value="--libs" />
                     </exec>
                     <mkdir dir="${basedir}/target" />
@@ -352,8 +352,8 @@
         <yaz.path>c:\Program Files\YAZ</yaz.path>
         <!-- import library -->
         <yaz.lib>${yaz.path}\lib\yaz5.lib</yaz.lib>
-        <!-- include directory for YAZ -->
-        <yaz.include>${yaz.path}\include</yaz.include>
+        <!-- CFLAGS with include directory for YAZ -->
+        <yaz.cflags>-I${yaz.path}\include</yaz.cflags>
         <jdk.include>${java.home}\include</jdk.include><!-- in some cases ..\include -->
         <!-- yaz.cflags: also passed to swig. Only -Defines and -Includes -->
         <yaz.cflags />
@@ -377,7 +377,7 @@
                       <arg value="-I${jdk.include}" />
                       <arg value="-I${jdk.include}/win32" />
                       <arg value="-I${basedir}/src/main/native" />
-                      <arg value="-I${yaz.include}" />
+                      <arg value="${yaz.cflags}" />
                       <arg value="/Fo${basedir}/target/zoom-extra.obj" />
                       <arg value="-c" />
                       <arg value="${basedir}/src/main/native/zoom-extra.cpp" />
@@ -387,7 +387,7 @@
                       <arg value="-I${jdk.include}" />
                       <arg value="-I${jdk.include}/win32" />
                       <arg value="-I${basedir}/src/main/native" />
-                      <arg value="-I${yaz.include}" />
+                      <arg value="${yaz.clags}" />
                       <arg value="/Fo${basedir}/target/libyaz4j.obj" />
                       <arg value="-c" />
                       <arg value="${basedir}/target/generated-sources/native/libyaz4j.cpp" />
@@ -446,4 +446,3 @@
   </distributionManagement>
 
 </project>
-

--- a/src/test/java/org/yaz4j/ConnectionExtendedTest.java
+++ b/src/test/java/org/yaz4j/ConnectionExtendedTest.java
@@ -10,7 +10,7 @@ public class ConnectionExtendedTest {
   
   @Test
   public void testRecordUpdate() {
-    ConnectionExtended con = new ConnectionExtended("z3950.indexdata.dk:210/gils", 0);
+    ConnectionExtended con = new ConnectionExtended("z3950.indexdata.com:210/gils", 0);
     assertNotNull(con);
     try {
       con.setSyntax("sutrs");
@@ -38,7 +38,7 @@ public class ConnectionExtendedTest {
   @Test
   public void testDatabaseDrop() {
     try {
-      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.dk:210/gils", 0);
+      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       Package create = conn.getPackage("create"); //db create

--- a/src/test/java/org/yaz4j/ConnectionTest.java
+++ b/src/test/java/org/yaz4j/ConnectionTest.java
@@ -15,7 +15,7 @@ public class ConnectionTest {
 
   @Test
   public void testConnectionScan() {
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       assertNotNull(con);
       con.setSyntax("sutrs");
       con.connect();
@@ -43,7 +43,7 @@ public class ConnectionTest {
 
   @Test
   public void testConnectionSorting() {
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       assertNotNull(con);
       con.setSyntax("sutrs");
       con.connect();
@@ -84,7 +84,7 @@ public class ConnectionTest {
 
   @Test
   public void testConnectionSortBy() {
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       assertNotNull(con);
       con.setSyntax("sutrs");
       con.connect();
@@ -136,7 +136,7 @@ public class ConnectionTest {
 
   @Test
   public void testRecords() {
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       assertNotNull(con);
       try {
         con.setSyntax("usmarc");
@@ -159,33 +159,33 @@ public class ConnectionTest {
   @Test
   public void connectionFailsConnectPort0() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:211", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:211", 0)) {
       assertNotNull(con);
       con.option("timeout", "1");
       con.connect();
     } catch (ZoomException ze) {
       msg = ze.getMessage();
     }
-    assertEquals("Server z3950.indexdata.dk:211 timed out handling our request", msg);
+    assertTrue(msg.contains("z3950.indexdata.com:211"));
   }
 
   @Test
   public void connectionFailsConnecPort211() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk", 211)) {
+    try (Connection con = new Connection("z3950.indexdata.com", 211)) {
       assertNotNull(con);
       con.option("timeout", "1");
       con.connect();
     } catch (ZoomException ze) {
       msg = ze.getMessage();
     }
-    assertEquals("Server z3950.indexdata.dk:211 timed out handling our request", msg);
+    assertTrue(msg.contains("z3950.indexdata.com:211"));
   }
 
   @Test
   public void connectionFailsSearchBadQuery() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.search(null, Connection.QueryType.PrefixQuery);
     } catch (IllegalArgumentException | ZoomException e) {
       msg = e.getMessage();
@@ -196,7 +196,7 @@ public class ConnectionTest {
   @Test
   public void connectionFailsSearchBadQueryType() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.search("utah", null);
     } catch (IllegalArgumentException | ZoomException e) {
       msg = e.getMessage();
@@ -207,7 +207,7 @@ public class ConnectionTest {
   @Test
   public void connectionFailsSearchBadQueryObject() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.search(null);
     } catch (IllegalArgumentException|ZoomException e) {
       msg = e.getMessage();
@@ -218,7 +218,7 @@ public class ConnectionTest {
   @Test
   public void connectionFailsScanBadQueryString() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.scan((String) null);
     } catch (IllegalArgumentException|ZoomException e) {
       msg = e.getMessage();
@@ -229,7 +229,7 @@ public class ConnectionTest {
   @Test
   public void connectionFailsScanBadQueryObject() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.scan((Query) null);
     } catch (IllegalArgumentException|ZoomException e) {
       msg = e.getMessage();
@@ -250,7 +250,7 @@ public class ConnectionTest {
 
   @Test
   public void connectionClosed() {
-    Connection con = new Connection("z3950.indexdata.dk:210/gils", 0);
+    Connection con = new Connection("z3950.indexdata.com:210/gils", 0);
     con.close();
     String msg = "";
     try {
@@ -266,7 +266,7 @@ public class ConnectionTest {
   @Test
   public void connectionOptionInvalid1() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.option(null, null);
     } catch (IllegalArgumentException e) {
       msg = e.getMessage();
@@ -277,7 +277,7 @@ public class ConnectionTest {
   @Test
   public void connectionOptionInvalid2() {
     String msg = "";
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       con.option(null);
     } catch (IllegalArgumentException e) {
       msg = e.getMessage();
@@ -287,7 +287,7 @@ public class ConnectionTest {
 
   @Test
   public void connectionOptionGetSet() {
-    try (Connection con = new Connection("z3950.indexdata.dk:210/gils", 0)) {
+    try (Connection con = new Connection("z3950.indexdata.com:210/gils", 0)) {
       assertNull(con.option("v1"));
       con.option("n1", "v1");
       assertEquals("v1", con.option("n1"));

--- a/src/test/java/org/yaz4j/ExceptionsTest.java
+++ b/src/test/java/org/yaz4j/ExceptionsTest.java
@@ -10,7 +10,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers4() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new CQLQuery(null));
@@ -25,7 +25,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers5() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new PrefixQuery(null));
@@ -40,7 +40,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers15() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new PrefixQuery("@attr 1=4 water"));
@@ -56,7 +56,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers16() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new PrefixQuery("@attr 1=4 water"));
@@ -72,7 +72,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers17() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new PrefixQuery("@attr 1=4 water"));
@@ -89,7 +89,7 @@ public class ExceptionsTest {
   @Test
   public void testRecordUnknownType() {
     try {
-      Connection conn = new Connection("z3950.indexdata.dk:210/gils", 0);
+      Connection conn = new Connection("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       ResultSet s = conn.search(new PrefixQuery("@attr 1=4 water"));
@@ -105,7 +105,7 @@ public class ExceptionsTest {
   @Test
   public void testNullPointers19() {
     try {
-      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.dk:210/gils", 0);
+      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       Package p = conn.getPackage(null);
@@ -120,7 +120,7 @@ public class ExceptionsTest {
   @Test
   public void testPackageOptionValueNull() {
     try {
-      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.dk:210/gils", 0);
+      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       Package p = conn.getPackage("some");
@@ -133,7 +133,7 @@ public class ExceptionsTest {
   @Test
   public void testPackageNameNull() {
     try {
-      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.dk:210/gils", 0);
+      ConnectionExtended conn = new ConnectionExtended("z3950.indexdata.com:210/gils", 0);
       conn.setSyntax("sutrs");
       conn.connect();
       Package p = conn.getPackage("some");

--- a/yaz-config-wrap.sh
+++ b/yaz-config-wrap.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# yaz-config is unavailable in Debian's libyaz-dev package and pkg-config
+# must be used instead.
+if which yaz-config >/dev/null 2>&1; then
+	exec yaz-config $1
+else
+	exec pkg-config $1 yaz
+fi


### PR DESCRIPTION
Use pkg-config on Linux as yaz-config is unavailable in offical Debian packages. Remove yaz.include definition and stick to yaz.cflags everywhere.