### PR TITLE
fix: use arg line instead of arg value for yaz.cflags in swig exec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
                 <mkdir dir="${native.dir}" />
                 <exec failonerror="true" executable="${swig}">
                   <arg value="-Isrc/main/native" />
-                  <arg value="${yaz.cflags}" />
+                  <arg line="${yaz.cflags}" />
                   <arg value="-I/usr/include" />
                   <arg value="-outdir" />
                   <arg value="${basedir}/target/generated-sources/java/org/yaz4j/jni" />


### PR DESCRIPTION
## Summary
  In the generate-sources antrun execution, yaz.cflags is passed to swig via \<arg value\>, 
  which treats the entire pkg-config --cflags yaz output as a single opaque argument.
  On any system where pkg-config returns multiple tokens (e.g. -I/... -DYAZ_POSIX_THREADS=1 -DYAZ_HAVE_XML2=1 ...), swig never receives the -I flag and exits with:

    Error: Unable to find 'yaz/zoom.h'

## Fix
  Change \<arg value="${yaz.cflags}"\> to \<arg line="${yaz.cflags}"\> in the swig exec block.
  \<arg line\> splits the value on whitespace and passes each token as a separate argument, which is the correct behaviour for compiler flag strings.

## Note
The Windows profile is just as broken ( Lines 376 and 386), but the fix is irrelevant there (unless there is a space in the path).